### PR TITLE
Mojo backward compat

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -54,7 +54,7 @@ jobs:
           test_equal "mojo should be installed" \
             "${{ steps.setup-mojo.outputs.installed }}" \
             "true"
-      - name: Validate script
+      - name: Validate script with magic
         if: ${{ matrix.os != 'windows' }}
         run: |
           unique_key="$(date +%s)"
@@ -68,6 +68,21 @@ jobs:
           echo 'fn main():' > "${script_filename}"
           echo '    print("Hello, world!")' >> "${script_filename}"
           [ "$(magic run mojo "${script_filename}")" = "Hello, world!" ] || exit 1;
+        working-directory: ${{ runner.temp }}
+      - name: Validate script with mojo
+        if: ${{ matrix.os != 'windows' }}
+        run: |
+          unique_key="$(date +%s)"
+          project_name="project-${unique_key}"
+          script_filename="script-${unique_key}.mojo"
+
+          magic init "${project_name}" --format mojoproject
+          cd "${project_name}"
+          mojo --version
+
+          echo 'fn main():' > "${script_filename}"
+          echo '    print("Hello, world!")' >> "${script_filename}"
+          [ "$(mojo "${script_filename}")" = "Hello, world!" ] || exit 1;
         working-directory: ${{ runner.temp }}
 
   test-force:

--- a/src/install-magic.sh
+++ b/src/install-magic.sh
@@ -7,7 +7,7 @@ main() {
   echo "$HOME/.modular/bin" >> "$GITHUB_PATH"
   # so people can use mojo instead of magic run mojo
   cat > "$HOME/.modular/bin/mojo" << EOF
-#!/bin/sh
+#!/usr/bin/env bash
 
 magic run mojo $*
 EOF

--- a/src/install-magic.sh
+++ b/src/install-magic.sh
@@ -12,6 +12,8 @@ main() {
 magic run mojo $*
 EOF
   chmod a+rx "$HOME/.modular/bin/mojo"
+  echo "Installed mojo compatibility script"
+  ls -l "$HOME/.modular/bin/mojo"
 }
 
 main "$@"

--- a/src/install-magic.sh
+++ b/src/install-magic.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
+# Installs magic and creates a mojo compatiblity script
+
 main() {
   curl -ssL https://magic.modular.com/8dc65f55-3ba2-410c-a46f-4f8f8102a7b7 | bash
   echo "$HOME/.modular/bin" >> "$GITHUB_PATH"
+  # so people can use mojo instead of magic run mojo
+  cat > "$HOME/.modular/bin/mojo" << EOF
+#!/bin/sh
+
+magic run mojo $*
+EOF
+  chmod a+rx "$HOME/.modular/bin/mojo"
 }
 
 main "$@"


### PR DESCRIPTION
People who used the v1 version of the action could run:

```
mojo hello.mojo
```

This script allows such code to continue working. It still requires `magic init $project_name`. Hopefully we can figure out a way to make it work without in the future.